### PR TITLE
Fix low-level comma mistake 👿

### DIFF
--- a/Map Generator.sketchplugin/Contents/Sketch/common.js
+++ b/Map Generator.sketchplugin/Contents/Sketch/common.js
@@ -8,7 +8,7 @@ var app              = NSApplication.sharedApplication();
  */
 function checkCount (context) {
   if (context.selection.count() != 1) {
-    app.displayDialog_withTitle('You have to select 1 shape layer.", "Wrong shape layer selection');
+    app.displayDialog_withTitle("You have to select 1 shape layer.", "Wrong shape layer selection");
     return false;
   }
 


### PR DESCRIPTION
Error Message: `Exception: ObjC method displayDialog:withTitle: requires 2 arguments, but JavaScript passed 1 argument`